### PR TITLE
set mf2util checkbox default to false

### DIFF
--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -66,7 +66,7 @@
 
       <div class="form-check">
         <label title="mf2util interprets certain post types (currently h-entry and h-event) and returns a normalized result" class="form-check-label" for="util">
-          <input id="util" name="util" class="form-check-input" type="checkbox" value="true" checked="checked">
+          <input id="util" name="util" class="form-check-input" type="checkbox" value="true">
           Process with mf2util
         </label>
       </div>


### PR DESCRIPTION
While mf2util is neat and deserves to be represented here, it keeps annoying me that I have to switch an additional thing to view the normal parser output