### PR TITLE
Update user agent used by the parser

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from flask import Flask, render_template, jsonify, request, make_response
 
 app = Flask(__name__)
 
-mf2py.Parser.user_agent = 'mf2.kylewm.com (mf2py v' + mf2py.__version__ + ')'
+mf2py.Parser.user_agent = "python.microformats.io (mf2py/" + mf2py.__version__ + ") Mozilla/5.0 Chrome/29.0.1547.57 Safari/537.36"
 mf2py.Parser.dict_class = collections.OrderedDict
 
 @app.route('/', methods=['GET', 'POST'])


### PR DESCRIPTION
This PR replaces the user agent string set in the `mf2py.Parser.user_agent` object. The new string displays:

1. The python.microformats.io domain.
2. The version of the mf2py parser that is running.
3. Mozilla, Chrome, and Safari user agents.

The user agent in this repository now follows a similar format to the one used in the PHP parser website (https://github.com/microformats/microformats-parser-website-php/blob/main/index.php#L46).