### PR TITLE
Render the commit hash on the page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import json
+import os
 import traceback
 from collections import OrderedDict
 
@@ -7,6 +8,8 @@ import mf2util
 from flask import Flask, jsonify, make_response, render_template, request
 
 app = Flask(__name__)
+
+COMMIT = os.environ.get("HEROKU_BUILD_COMMIT", "")
 
 mf2py.Parser.user_agent = "python.microformats.io (mf2py/" + mf2py.__version__ + ") Mozilla/5.0 Chrome/29.0.1547.57 Safari/537.36"
 mf2py.Parser.dict_class = OrderedDict
@@ -50,7 +53,11 @@ def index():
                 response.headers["Content-Type"] = "application/json"
             return response
 
-        return render_template("index.jinja2", mf2py_version=mf2py.__version__)
+        return render_template(
+            "index.jinja2",
+            mf2py_version=mf2py.__version__,
+            commit=COMMIT,
+        )
     except BaseException as e:
         traceback.print_exc()
         return jsonify(error="%s: %s" % (type(e).__name__, e)), 400

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -114,6 +114,7 @@
         </li>
       </ul>
     </footer>
+    {% if commit %}<!-- commit: {{ commit }} -->{% endif %}
 
   </main>
 </body>


### PR DESCRIPTION
Not sure if this is a good idea, but it would allow us to check which commit from the repository is actually being used by the website. Gives a quick sanity check on the state of the Heroku build.

This uses an environment variable [inserted by Heroku](https://devcenter.heroku.com/articles/heroku-24-stack):

> If you need to determine the currently deployed revision of your app, either use the env var `SOURCE_COMMIT` during the build, or enable the [Dyno Metadata](https://devcenter.heroku.com/articles/dyno-metadata) feature and use the env var `HEROKU_BUILD_COMMIT` at run time.

@aaronpk if I have understood [the Heroku docs correctly](https://devcenter.heroku.com/articles/dyno-metadata), this needs some flag to be enabled by you?

```
heroku labs:enable runtime-dyno-metadata -a <app name>
heroku labs:enable runtime-dyno-build-metadata -a <app name>
```